### PR TITLE
Change dependency version syntax for Rails gem.

### DIFF
--- a/unlock_auto_html.gemspec
+++ b/unlock_auto_html.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 4.1.6"
+  s.add_dependency "rails", "~> 4", ">= 4.1.6"
   s.add_dependency "RedCloth"
   s.add_dependency "auto_html", "1.5.1"
 


### PR DESCRIPTION
This will enable update to newer Rails 4 versions.
Still requires version 4.1.6 as minimum version.